### PR TITLE
Remove unused folder

### DIFF
--- a/sig/rspec_tests.rbs
+++ b/sig/rspec_tests.rbs
@@ -1,4 +1,0 @@
-module RspecTests
-  VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
-end


### PR DESCRIPTION
This PR:
- Removes the unused `sig` folder left over from initializing this repo as a gem.