### PR TITLE
Add headless rake command and update GitHub yaml to use it

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Run Rubocop
       run: bundle exec rake rubocop
     - name: Run tests
-      run: bundle exec rake spec
+      run: bundle exec rake spec_headless

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,17 @@
 
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+desc "Run all tests headless"
+task 'spec_headless' do
+  ENV["HEADLESS"] = 'true'
+  RSpec::Core::RakeTask.new(:spec_headless)
+end
+
+desc "Run all tests headful."
+task 'spec' do
+  ENV["HEADLESS"] = 'false'
+  RSpec::Core::RakeTask.new(:spec)
+end
 
 require "rubocop/rake_task"
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,14 +3,14 @@
 require "rspec/core/rake_task"
 
 desc "Run all tests headless"
-task 'spec_headless' do
-  ENV["HEADLESS"] = 'true'
+task "spec_headless" do
+  ENV["HEADLESS"] = "true"
   RSpec::Core::RakeTask.new(:spec_headless)
 end
 
 desc "Run all tests headful."
-task 'spec' do
-  ENV["HEADLESS"] = 'false'
+task "spec" do
+  ENV["HEADLESS"] = "false"
   RSpec::Core::RakeTask.new(:spec)
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,12 @@ require "pry"
 
 Capybara.default_driver = :selenium_headless
 
+Capybara.default_driver = if ENV["HEADLESS"] == 'true'
+                            :selenium_headless
+                          else
+                            :selenium
+                          end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "pry"
 
 Capybara.default_driver = :selenium_headless
 
-Capybara.default_driver = if ENV["HEADLESS"] == 'true'
+Capybara.default_driver = if ENV["HEADLESS"] == "true"
                             :selenium_headless
                           else
                             :selenium


### PR DESCRIPTION
This PR:
- Adds an environment variable to control when headless/headful Selenium is used.
- Splits the RSpec rake tasks into two: one headless and one headful
- Updates the GitHub Action to use the headless rake task.